### PR TITLE
Expose consumer 'isolation_level' so it can be set up

### DIFF
--- a/src/brod_kafka_request.erl
+++ b/src/brod_kafka_request.erl
@@ -19,7 +19,7 @@
 
 -export([ create_topics/3
         , delete_topics/3
-        , fetch/7
+        , fetch/8
         , list_groups/1
         , list_offsets/4
         , join_group/2
@@ -77,14 +77,16 @@ delete_topics(Vsn, Topics, Timeout) ->
 %% @doc Make a fetch request, If the first arg is a connection pid, call
 %% `brod_kafka_apis:pick_version/2' to resolve version.
 -spec fetch(conn(), topic(), partition(), offset(),
-            kpro:wait(), kpro:count(), kpro:count()) -> kpro:req().
+            kpro:wait(), kpro:count(), kpro:count(),
+            kpro:isolation_level()) -> kpro:req().
 fetch(Pid, Topic, Partition, Offset,
-      WaitTime, MinBytes, MaxBytes) ->
+      WaitTime, MinBytes, MaxBytes, IsolationLevel) ->
   Vsn = pick_version(fetch, Pid),
   kpro_req_lib:fetch(Vsn, Topic, Partition, Offset,
                      #{ max_wait_time => WaitTime
                       , min_bytes => MinBytes
                       , max_bytes => MaxBytes
+                      , isolation_level => IsolationLevel
                       }).
 
 %% @doc Make a `list_offsets' request message for offset resolution.

--- a/test/brod_consumer_SUITE.erl
+++ b/test/brod_consumer_SUITE.erl
@@ -467,10 +467,11 @@ t_consumer_max_bytes_too_small(Config) ->
   MaxBytes2 = 12, %% too small but message size is fetched
   MaxBytes3 = size(Key) + ValueBytes,
   Tester = self(),
-  F = fun(Conn, Topic, Partition1, BeginOffset, MaxWait, MinBytes, MaxBytes) ->
+  F = fun(Conn, Topic, Partition1, BeginOffset, MaxWait,
+          MinBytes, MaxBytes, IsolationLevel) ->
         Tester ! {max_bytes, MaxBytes},
         meck:passthrough([Conn, Topic, Partition1, BeginOffset,
-                          MaxWait, MinBytes, MaxBytes])
+                          MaxWait, MinBytes, MaxBytes, IsolationLevel])
       end,
   %% Expect the fetch_request construction function called twice
   meck:expect(brod_kafka_request, fetch, F),


### PR DESCRIPTION
## Description

Currently, consumers always use `read_commited` isolation level whether transactions are being used or not. This PR exposes it so it can be configured per consumer as required.